### PR TITLE
basic bulb-controls added

### DIFF
--- a/src/LIFX Menu.py
+++ b/src/LIFX Menu.py
@@ -20,18 +20,76 @@ class LifxMenu(NSObject):
 		menu = NSMenu.alloc().init()
 		self.toggle_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_('Toggle lights', 'toggle:', '')
 		menu.addItem_(self.toggle_item)
-		quit_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_('Quit', 'terminate:', '')
-		menu.addItem_(quit_item)
 		self.status_item.setMenu_(menu)
 
 		self.lights = lifx.get_lights()
 		self.toggle_item.setState_(self.lights[0].power)
+
+		submenu =  NSMenu.alloc().init()
+		item =  NSMenuItem.alloc().initWithTitle_action_keyEquivalent_( 'Colours', '', '')
+		item.setSubmenu_( submenu )
+		menu.addItem_( item )
+		subitem =  NSMenuItem.alloc().initWithTitle_action_keyEquivalent_( 'White', 'setColour:', '')
+		subitem.setRepresentedObject_( 'White' )
+		submenu.addItem_( subitem )
+		subitem =  NSMenuItem.alloc().initWithTitle_action_keyEquivalent_( 'Red', 'setColour:', '')
+		subitem.setRepresentedObject_( 'Red' )
+		submenu.addItem_( subitem )
+		subitem =  NSMenuItem.alloc().initWithTitle_action_keyEquivalent_( 'Green', 'setColour:', '')
+		subitem.setRepresentedObject_( 'Green' )
+		submenu.addItem_( subitem )
+		subitem =  NSMenuItem.alloc().initWithTitle_action_keyEquivalent_( 'Blue', 'setColour:', '')
+		subitem.setRepresentedObject_( 'Blue' )
+		submenu.addItem_( subitem )
+
+
+		for bulb in self.lights:
+			submenu =  NSMenu.alloc().init()
+			item =  NSMenuItem.alloc().initWithTitle_action_keyEquivalent_( bulb.get_addr(), '', '')
+			item.setSubmenu_( submenu )
+			menu.addItem_( item )
+			subitem =  NSMenuItem.alloc().initWithTitle_action_keyEquivalent_( 'Toggle light', 'toggleBulb:', '')
+			subitem.setRepresentedObject_( bulb )
+			subitem.setState_(bulb.power)
+			submenu.addItem_( subitem )
+
+			
+		quit_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_('Quit', 'terminate:', '')
+		menu.addItem_(quit_item)
+
+
 
 	def toggle_(self, notification):
 		state = not self.lights[0].power
 		for bulb in self.lights:
 			bulb.set_power(state)
 		self.toggle_item.setState_(self.lights[0].power)
+
+	def toggleBulb_(self, notification):
+		bulb = notification._.representedObject
+		state = not bulb.power
+		bulb.set_power(state)
+		notification.setState_(bulb.power)
+
+	def setColour_(self, notification):
+		hue = 0;
+		saturation = 65535
+		colour = notification._.representedObject
+		if colour == 'White' :
+			hue = 9802
+			saturation = 10023
+		if colour == 'Red' :
+			hue = 0
+			saturation = 65535
+		if( colour == 'Green' ):
+			hue = 65535/360*120
+			saturation = 65535
+		if( colour == 'Blue' ):
+			hue = 65535/360*240
+			saturation = 65535
+		for bulb in self.lights:
+			bulb.set_color( hue, saturation, 65535, 3500, 1000)
+
 
 if __name__ == "__main__":
     app = NSApplication.sharedApplication()


### PR DESCRIPTION
Made some basic changes, submenu per-bulb for power (And perhaps later other things)

No idea if this is ca the direction you're heading, but figured I'd share
- Discrete bulb control (power only)
- Global bulb-color options (basic)
